### PR TITLE
Add deps.edn file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/.cpcache/

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:deps
+ {org.clojure/clojure {:mvn/version "1.8.0"}}}


### PR DESCRIPTION
This change adds a minimal deps.edn file.

This is required when dependent projects specify their dependency on reducible-stream using Git SHAs. If no deps.edn manifest is present, no `clj` REPL can be launched:

    Error building classpath. Manifest type not detected when finding deps for pjstadig/reducible-stream in coordinate {:git/url "https://github.com/pjstadig/reducible-stream.git", :sha "cb7b5f60faa6b68fea584960efb42586f70f4559"}

Thank you!
