### PR TITLE
Reducible streams do not implement clojure.lang.Sequential

### DIFF
--- a/src/pjstadig/reducible_stream.clj
+++ b/src/pjstadig/reducible_stream.clj
@@ -94,7 +94,8 @@
                 (close stream))))))
        clojure.lang.Seqable
        (seq [this]
-         (seq (into [] this)))))))
+         (seq (into [] this)))
+       clojure.lang.Sequential))))
 
 (defn lines-open
   "Used as the open function for decoding text.  Returns a


### PR DESCRIPTION
This change makes reducible streams implement `clojure.lang.Sequential`.

The reducible and seqable value returned by `decode!` does not implement `clojure.lang.Sequential`, even though it is sequential. I believe it is common and beneficial for such values to implement that marker interface, as it enables some interopability with consumers that rely on that marker (eg sequence specs).

Example: this program prints `false` now, `true` with the change applied.

    echo 1 2 3 | clj -e "(use 'pjstadig.reducible-stream) (= [1 2 3] (decode-edn! *in*))"

Thank you.
